### PR TITLE
Fix #41 (failure with empty observables)

### DIFF
--- a/TA-thehive-cortex/bin/ta_thehive_cortex/modalert_thehive_create_a_new_alert_helper.py
+++ b/TA-thehive-cortex/bin/ta_thehive_cortex/modalert_thehive_create_a_new_alert_helper.py
@@ -529,10 +529,11 @@ def create_alert(helper, thehive_api, alert_args):
                         if artifact not in artifacts:
                             artifacts.append(artifact)
 
+        alert['artifacts'] = list(artifacts)
+        alert['customFields'] = customFields
+        alerts[sourceRef] = alert
+
         if artifacts:
-            alert['artifacts'] = list(artifacts)
-            alert['customFields'] = customFields
-            alerts[sourceRef] = alert
             helper.log_debug("[CAA-THCA-115] Artifacts found for an alert: " + str(artifacts))
         else:
             helper.log_debug("[CAA-THCA-116] No artifact found for an alert: " + str(alert))


### PR DESCRIPTION
Faced with the necessity to be able to create an alert without observable parameters in my own productive environment