### PR TITLE
fix: robustness fixes for alert action parse_events() (KeyError, NameError, observable splitting, timestamp handling)

### DIFF
--- a/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
+++ b/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
@@ -697,7 +697,7 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
             if not isinstance(mitre_technics, list):
                 mitre_technics = [mitre_technics]
 
-            date = datetime.datetime.fromtimestamp(int(row.get("_time", time.time()))).strftime(
+            date = datetime.datetime.fromtimestamp(int(float(row.get("_time", time.time())))).strftime(
                 "%Y-%m-%d"
             )
             alert["ttps"] = []

--- a/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
+++ b/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
@@ -423,7 +423,12 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
                 id="THC-85", message="alert timestamp: {} ".format(alert["timestamp"])
             )
         else:
-            alert["timestamp"] = arg_timestamp if arg_timestamp else int(time.time() * 1000)
+            if arg_timestamp:
+                thehive.logger_file.warn(
+                    id="THC-86",
+                    message=f"timestamp_field '{arg_timestamp}' missing; falling back to current time",
+                )
+            alert["timestamp"] = int(time.time() * 1000)
 
         observables_data = dict()
         # now we take those KV pairs to add to dict

--- a/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
+++ b/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
@@ -612,7 +612,7 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
                 if "value" in data:
                     # Multi-value support: split by comma, semicolon, pipe or newline
                     raw_val_str = str(data["value"])
-                    raw_values = [v.strip() for v in re.split(r'[,;|\\n]+', raw_val_str) if v.strip()]
+                    raw_values = [v.strip() for v in re.split(r'[,;|\n]+', raw_val_str) if v.strip()]
                     
                     thehive.logger_file.debug(
                         id="THC-112",

--- a/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
+++ b/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
@@ -343,8 +343,8 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
             # Find the most accurate information for the title
             if "search_name" in row:
                 # Use this information coming from Splunk ES
-                del row_sanitized["search_name"]
                 alert["title"] = row["search_name"]
+                del row_sanitized["search_name"]
             else:
                 # Take the name of the savedsearch itself
                 alert["title"] = helper.settings["search_name"]
@@ -409,7 +409,6 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
         # and strip it from the row
         arg_timestamp = alert_args.get("timestamp")
         if arg_timestamp and arg_timestamp in row:
-            del row_sanitized[arg_timestamp]
             newTimestamp = str(int(float(row.pop(arg_timestamp))))
             thehive.logger_file.debug(
                 id="THC-80", message="new Timestamp from row: {} ".format(newTimestamp)

--- a/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
+++ b/TA-thehive-cortex/package/bin/ta_thehive_cortex/modalert_thehive_common.py
@@ -671,7 +671,7 @@ def parse_events(helper, thehive: TheHive4Splunk, alert_args):
         else:
             alert["observables"] = []
             thehive.logger_file.debug(
-                id="THC-116", message=f"No observable found in current row (sourceRef={srcRef})."
+                id="THC-116", message=f"No observable found in current row (sourceRef={sourceRef})."
             )
         # Process customFields
         alert["customFields"] = [InputCustomField(cf) for cf in customFields]


### PR DESCRIPTION
Fixes several bugs in the alert action code path, all in `modalert_thehive_common.py` (so they affect every alert action that calls `parse_events()`: `thehive_create_a_new_alert`, `thehive_create_a_new_case`, and `thehive_add_observables`). We observed and reproduced 1, 2, and 3 in our environment; 4 and 5 were found while investigating the others.

Three of these are regressions introduced in v4.X, while two are pre-existing.

### 1. KeyError in row_sanitized timestamp handling

This crashes alert creation entirely, indicated by `Unexpected error: '_time'.` in audit logs.

**Fix:** [fix: improve handling of row_sanitized to avoid KeyErrors](https://github.com/LetMeR00t/TA-thehive-cortex/commit/e2606368e6d5de6e7a3b398bbc61ed4c29159be2)

### 2. NameError in observable-empty debug log

This crashes alert creation entirely, indicated by `Unexpected error: name 'srcRef' is not defined.` in audit logs. Since f-strings are eagerly evaluated, this will trigger regardless of the set log level.

**Fix:** [fix: correct sourceRef variable name in debug logging statement](https://github.com/LetMeR00t/TA-thehive-cortex/commit/47131546d9f7396abba46d91e4934f587163ca18)

### 3. Multi-value observable split matched the letter `n` instead of newline

This causes observables sent to TheHive to be incorrectly fragmented. It can be seen in audit logs as:
```
[THCA-THC-112] Multi-value split for file_name: 'file_name: test.txt' -> ['file_', 'ame: test.txt']
```
**Fix:** [fix: multi-value observable split was matching the letter 'n' instead of newline](https://github.com/LetMeR00t/TA-thehive-cortex/commit/a120c2a5c0a44bb70c728e91fd987ce48254b896)

### 4. Literal field-name string left in `alert["timestamp"]` when configured field is missing from row

When `arg_timestamp` is set, but the field doesn't exist, the original else branch assigns the `arg_timestamp` field name to `alert["timestamp"]`. The helper later calls `int(alerts[srcRef]["timestamp"])` on what would be a string, leading to a `ValueError`. We have not observed this directly, as our searches populate `_time`, but a misconfigured `timestamp_field` would trigger this.

**Fix:** [fix: fall back to current time when configured timestamp_field is missing](https://github.com/LetMeR00t/TA-thehive-cortex/commit/3779003607f29ea186fd9a27a05c1e6920165632) and emit a warning so the misconfiguration is visible.

### 5. `int(row.get("_time", ...))` in TTP extraction can't parse float-string `_time`

This would raise `ValueError` when `_time` arrives as a string like `1778051317.123`, which is typical for Splunk. We have not observed this directly, but the same `int(float(` pattern is used to parse timestamps elsewhere in this file.

**Fix:** [fix: parse _time as float when processing TTPs](https://github.com/LetMeR00t/TA-thehive-cortex/commit/8f715dc35a930722b6fd989476d528c227c154d4)

---

Separately, as a consideration: adding unit tests would help to catch these and similar classes of regressions. This could be achieved by calling `parse_events(helper, thehive, alert_args)` directly with a few pre-defined JSON payloads and asserting that no exceptions are thrown and the emitted `InputAlert` matches expectations (`helper` and `thehive` would need to be stubbed out).